### PR TITLE
feat: Default to light theme and persist selection

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -67,6 +67,14 @@ function changeTheme() {
     // Si se cumple la validación, preguntamos cuál fue el problema para saber si activamos o desactivamos el dark theme
     document.body.classList[selectedTheme === "light-theme" ? "add" : "remove"](lightTheme);
     themeIcon.classList[selectedIcon === "ri-sun-fill" ? "add" : "remove"](iconTheme);
+  } else {
+    // Si no hay tema seleccionado (primera visita), establecemos el tema claro por defecto
+    document.body.classList.add(lightTheme);
+    themeIcon.classList.add(iconTheme);
+    // Aseguramos que el ícono de luna no esté presente si estamos estableciendo el sol por defecto
+    themeIcon.classList.remove("ri-moon-fill"); // Aunque iconTheme es ri-sun-fill, es bueno ser explícito.
+    localStorage.setItem("selected-theme", "light-theme");
+    localStorage.setItem("selected-icon", "ri-sun-fill");
   }
 
   // Activamos / desactivamos el tema manualmente con el botón


### PR DESCRIPTION
Modified assets/js/main.js to make the light theme the default when you first visit the site.

The `changeTheme()` function was updated so that if no theme preference is found in localStorage:
- The 'light-theme' class is applied to the body.
- The theme icon defaults to 'ri-sun-fill'.
- These preferences are saved to localStorage for subsequent visits.

The theme toggle button functionality remains, allowing you to switch to the dark theme, and this choice will also be persisted in localStorage.